### PR TITLE
FIX: Build Break: Incorrect API export macro used

### DIFF
--- a/include/flecs-util/strbuf.h
+++ b/include/flecs-util/strbuf.h
@@ -70,7 +70,7 @@ typedef struct ecs_strbuf_t {
 
 /* Append format string to a buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_append(
     ecs_strbuf_t *buffer,
     const char *fmt,
@@ -78,7 +78,7 @@ bool ecs_strbuf_append(
 
 /* Append format string with argument list to a buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_vappend(
     ecs_strbuf_t *buffer,
     const char *fmt,
@@ -86,77 +86,77 @@ bool ecs_strbuf_vappend(
 
 /* Append string to buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_appendstr(
     ecs_strbuf_t *buffer,
     const char *str);
 
 /* Append source buffer to destination buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_mergebuff(
     ecs_strbuf_t *dst_buffer,
     ecs_strbuf_t *src_buffer);
 
 /* Append string to buffer, transfer ownership to buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_appendstr_zerocpy(
     ecs_strbuf_t *buffer,
     char *str);
 
 /* Append string to buffer, do not free/modify string.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_appendstr_zerocpy_const(
     ecs_strbuf_t *buffer,
     const char *str);
 
 /* Append n characters to buffer.
  * Returns false when max is reached, true when there is still space */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_appendstrn(
     ecs_strbuf_t *buffer,
     const char *str,
     uint32_t n);
 
 /* Return result string (also resets buffer) */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 char *ecs_strbuf_get(
     ecs_strbuf_t *buffer);
 
 /* Reset buffer without returning a string */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 void ecs_strbuf_reset(
     ecs_strbuf_t *buffer);
 
 /* Push a list */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 void ecs_strbuf_list_push(
     ecs_strbuf_t *buffer,
     const char *list_open,
     const char *separator);
 
 /* Pop a new list */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 void ecs_strbuf_list_pop(
     ecs_strbuf_t *buffer,
     const char *list_close);
 
 /* Insert a new element in list */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 void ecs_strbuf_list_next(
     ecs_strbuf_t *buffer);
 
 /* Append formatted string as a new element in list */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_list_append(
     ecs_strbuf_t *buffer,
     const char *fmt,
     ...);
 
 /* Append string as a new element in list */
-UT_EXPORT
+FLECS_UTIL_EXPORT
 bool ecs_strbuf_list_appendstr(
     ecs_strbuf_t *buffer,
     const char *str);


### PR DESCRIPTION
Looks like the bug was just a typo/vestsige from previous bake iteration.
Solution: Replace UT_EXPORT with FLECS_UTIL_EXPORT